### PR TITLE
updated the mapper to use new LPK/NPK/CPK flags

### DIFF
--- a/src/MM_GMCP_Mapper_GMCP.xml
+++ b/src/MM_GMCP_Mapper_GMCP.xml
@@ -20,7 +20,7 @@
   purpose="GMCP Mapper for Materia Magica"
   save_state="y"
   date_written="2012-02-03 20:26:09"
-  date_modified="2020-12-07 18:08:56"
+  date_modified="2020-12-16 18:23:42"
   requires="4.71"
   version="1.0"
 >
@@ -1479,7 +1479,7 @@ function get_room(uid)
     room.fillcolour = config.SAFE_FILL_COLOUR.colour
     room.fillbrush = 8
 
-  elseif (has_flag(room.flags, "player-kill-chaotic")) then
+  elseif (has_flag(room.flags, "player-kill-chaotic") or has_flag(room.flags, "CPK")) then
     room.fillcolour = config.CPK_FILL_COLOUR.colour
     room.fillbrush = 8
 
@@ -1495,11 +1495,11 @@ function get_room(uid)
     room.fillcolour = config.SHOP_FILL_COLOUR.colour
     room.fillbrush = 8
 
-  elseif (has_flag(room.flags, "player-kill-neutral")) then
+  elseif (has_flag(room.flags, "player-kill-neutral") or has_flag(room.flags, "NPK")) then
     room.fillcolour = config.NPK_FILL_COLOUR.colour
     room.fillbrush = 8
 
-  elseif (has_flag(room.flags, "player-kill-lawful")) then
+  elseif (has_flag(room.flags, "player-kill-lawful") or has_flag(room.flags, "LPK")) then
     room.fillcolour = config.LPK_FILL_COLOUR.colour
     room.fillbrush = 8
 
@@ -2063,7 +2063,7 @@ function map_find(name, line, wildcards)
     end
 
     local cpk = ""
-    if (has_flag(room.flags, "player-kill-chaotic")) then
+    if (has_flag(room.flags, "player-kill-chaotic") or has_flag(room.flags, "CPK")) then
       cpk = red .. bold .. " [CPK]"
     end
 
@@ -2321,7 +2321,7 @@ function show_hyperlinks(t)
     Tell("room: ")
     Hyperlink ("mapper goto " .. t[i], room.name, "", "white", bgcol, false)
 
-    if (has_flag(room.flags, "player-kill-chaotic")) then
+    if (has_flag(room.flags, "player-kill-chaotic") or has_flag(room.flags, "CPK")) then
       ColourTell("red", bgcol, " [CPK]")
     end
 
@@ -2428,7 +2428,7 @@ function map_cpk()
     return
   end
 
-  map_where_by_flags("player-kill-chaotic")
+  map_where_by_flags("player-kill-chaotic CPK")
 end
 
 
@@ -3207,9 +3207,9 @@ function do_load_room(uid)
     else
       room.flags = row.description
       room.flags = fix_flag(room.flags, row.safe, "safe")
-      room.flags = fix_flag(room.flags, row.lpk, "player-kill-lawful")
-      room.flags = fix_flag(room.flags, row.npk, "player-kill-neutral")
-      room.flags = fix_flag(room.flags, row.cpk, "player-kill-chaotic")
+      room.flags = fix_flag(room.flags, row.lpk, "LPK", "player-kill-lawful")
+      room.flags = fix_flag(room.flags, row.npk, "NPK", "player-kill-neutral")
+      room.flags = fix_flag(room.flags, row.cpk, "CPK", "player-kill-chaotic")
 
       room.notes = row.notes
 
@@ -3259,9 +3259,10 @@ function room_exits(uid)
 end
 
 
-function fix_flag(flags, field, flag)
+function fix_flag(flags, field, flag, old_flag)
   if (is_true(field))
-  and (not has_flag(flags, flag)) then
+  and (not has_flag(flags, flag))
+  and (not old_flag or not has_flag(flags, old_flag)) then
     flags = add_a_flag(flags, flag)
   end
 
@@ -3414,6 +3415,11 @@ function map_add_bookmark(name, line, wildcards)
   local room = load_room_from_database(id)
   if (not room) then
     mapper.mapprint("The room", id, "isn't in the map.")
+    return
+  end
+  
+  if (room.notes == new_note) then
+    -- same notes as before, don't change anything
     return
   end
 

--- a/src/mm_mapper.lua
+++ b/src/mm_mapper.lua
@@ -4,6 +4,9 @@
 
 Mods: Ruthgul, for Materia Magica
 
+2020-12016
+* Added support for new LPK, NPK, CPK room flags
+
 2020-09-26
 * Added support for grapple-required rooms (to be excluded by the pathfinder if grappling mode is off)
 * Added grappling mode (use / avoid grapple-required rooms)
@@ -804,7 +807,8 @@ end
 local function is_safewalk_check_ok(uid)
   return (not safewalk_mode)
     or (
-      (not is_room_flagged_as(uid, "player%-kill%-"))
+      (not is_room_flagged_as(uid, "PK"))
+      and (not is_room_flagged_as(uid, "player%-kill%-"))
       and (not is_room_tagged_as(uid, "dt"))
     )
 end

--- a/text/create-plugins-versions.py
+++ b/text/create-plugins-versions.py
@@ -20,14 +20,14 @@ def create_plugins_versions():
 
 
 def process_plugins(path, pattern):
-  for f in glob.glob(os.path.join(path, pattern)):
+  for f in sorted(glob.glob(os.path.join(path, pattern)), key=os.path.basename):
     details = find_plugin_details(f)
     details['hash'] = calc_hash(f)
     show_plugin_info(details)
 
 
 def process_other(path, pattern):
-  for f in glob.glob(os.path.join(path, pattern)):
+  for f in sorted(glob.glob(os.path.join(path, pattern)), key=os.path.basename):
     details = {
       'name': os.path.basename(f),
       'hash': calc_hash(f),

--- a/text/plugins_versions.txt
+++ b/text/plugins_versions.txt
@@ -1,118 +1,118 @@
-id = 233091f6c00f9afb14a2af62  hash = 91DAE348474D47648644945A2C3C92BF  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = f67c4339ed0591a5b010d05b  hash = 19843325EE9DBAA5D4B629228EE0C9E5  aux_files = {   [1] = {     name = "gmcphelper.lua",     dest = "MUSH/lua",     },   [2] = {     name = "sandbox.dune.net.MCL",     dest = "MUSH/worlds",     },   }
-id = f973af093e715dece34dc25f  hash = DFEE7E6605E82CA93C18EA80DCFD40E3  aux_files = {   [1] = {     name = "mm_mapper.lua",     dest = "MUSH/lua",     },   }
-id = 7daf1d7890d9db73d74a8188  hash = D76B7EE02EE2A3C2F5D23F9B274D94E4
-id = b2772cad800b33a6073d9377  hash = 1A954242DD7D93D4CFB40B0107B2A789  aux_files = {   [1] = {     name = "captures.MCL",     dest = "MUSH/worlds",     },   [2] = {     name = "announce.mp3",     dest = "MUSH/sounds",     },   }
-id = f99134f19ea994a0cc0888d1  hash = 2B8F2A164C0E86DFE98009A06493587E
-id = e377771aeee520a633f3dd4d  hash = BA5CDA1963FF9F5E15776E201DB9ED19
-id = da9c885cd98fd213dd8f719a  hash = 37159BDD68C7591F971A155BB4B95DCA
-id = a6ef71f61368df7da2fcf5a6  hash = 7AC96AA0929EB975E892E7A6AEF46BB9
-id = adc3a873d4e47348da7cb426  hash = D4639AD634A8C0013DA12D226DC98E7D  aux_files = {   [1] = {     name = "arrow.png",     },   [2] = {     name = "circ.png",     },   [3] = {     name = "cross.png",     },   [4] = {     name = "custom.png",     },   [5] = {     name = "dest.png",     },   [6] = {     name = "horse.png",     },   [7] = {     name = "ship.png",     },   [8] = {     name = "alyria.png",     },   [9] = {     name = "alyria_spk_purple.png",     },   [10] = {     name = "alyria_spk_red.png",     },   [11] = {     name = "fp.png",     },   [12] = {     name = "lasler.png",     },   [13] = {     name = "social.png",     },   [14] = {     name = "sugx.png",     },   [15] = {     name = "ug.png",     },   [16] = {     name = "verity.png",     },   }
-id = 463242566069ebfd1b379ec1  hash = 661C7BA2F78BCE66507A5DFD619F0BC1
-id = 4327c10cd9ae383bef04a7fc  hash = 2CA7206FE1FC784960025F0E016C91B9
-id = 29aff4e19e96d79f40ffcbd6  hash = 1762150CF863FB19954DAF81EB491516
-id = 97784abf5f30629a0d7e7307  hash = 1FB4EBDE61F109C1D0C2815E38EDA006
-id = 616b8084d0f246d12d54588b  hash = D72ED2293551ABAB728E51CEB7E03F2E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = fdebcc7a082dc4e7c6d4c306  hash = 51F28819EC963F6AEC3D56B1E793D73E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = ce9475a5d7acf80d07396cac  hash = 2714B0BDDB7F1A0421287EAF6DB85F92
-id = 632048f8236c5a1319306ff6  hash = 62A4C2D8E7E13133C4742DD244E10224
-id = 57ba85788195beece2a1a171  hash = F20CAE9FDAF57FA789806ED3EA72347B
-id = 4df60011beba94a6b9e41859  hash = 13BFE477E47C3F2377A5A9BE450D5E77
-id = 54846c23d8b15594e7eb4b8a  hash = 14E0D769B3192F4B43BC2D5EE5F14470
-id = 1079f88c024e8171e2d91e76  hash = FF82E55CDA7CCCB882FF49B4AF233113
-id = fbd5b7cc1ef6acf827a3f4a1  hash = F1C24EFCF6BB89348D62900026B2DE7C  aux_files = {   [1] = {     name = "async.lua",     dest = "MUSH/lua",     },   [2] = {     name = "ssl.lua",     dest = "MUSH/lua",     },   [3] = {     name = "https.lua",     dest = "MUSH/lua/ssl",     },   }
-id = 51a661f409c5d66601ff16e9  hash = C65C63FC0505935B7304512EF61320E4  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 84cc0397252aec0dbd589eaa  hash = F0AFB1723D2AE53FA615773488AEECE1
-id = ffc9367251d8355fc40c4f67  hash = 9B07AAFC27F4D9292A4A80314B762B4E
-id = bb2a97fe72b34a0cd5135bcf  hash = 4EC4093F5BE5BC40CE73E53E9DFF9B2E
-id = 4f76c77c73affc51fa8fc841  hash = 89D928CEC6BC9728F682835D1CE52A15
-id = 366aa79676f9fb1941eb5f69  hash = 559B677EBBFF0C67D154256671D7D558
-id = 226fb67b0722e0f0ddc3a235  hash = 18E699E79A31D4417919489EDF74C41B
-id = a326b480b3f02b3ff6d58e7d  hash = 1FDEEDA61179DF786CE9F23BE2E259C1
-id = 164db33914b912da8aac6ecc  hash = D80F101FB7D7B4B6238E2B8BE8D511A7
-id = d83fdde9ed133fb0859936a6  hash = DB58EAA5FA1DFC5733DB8379190BC91B
-id = dc22833520922eacc933b2ac  hash = C4117AF629283A51CD25E67A89CAA1E7
-id = 66f8ef96f2166bb586529087  hash = EBDA2240869865A4D3919428330F6FF8
-id = d2b442f2da9a95f34f5a199f  hash = F8564564C1118A7CB5EEEF6E80B24493  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 909d8c23b717f4de1262d0a4  hash = 9F7611B9C3E432737BF55CC7BD8FE4D7
-id = d54ccc4800e5df1ad0ed0aac  hash = 4621EB3AF63B0B777056D7F11D5FA14B
-id = ed9db27b1b50b46624e21eb4  hash = 103CACBCA97FE6985D0CB4A4B440CA80
-id = 47150df0ca58b162ea22b396  hash = 2D8100533E6FFDDE8871DB6FD3B999FB
-id = 7ccd9d550eaeedb90ed0825d  hash = 2623D4EF22BA8BE74CFE5A4F3D0D806D
-id = cb6469228f9f7e26129c1ebc  hash = A4F1F8215F5AA3F7CFBF293CB016831E  aux_files = {   [1] = {     name = "world_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 15160c25503baa781f667459  hash = CA92B58A780859FBD94348F0E524E863
-id = d75d47db12b5271e7e063d46  hash = 53B7E57CC678F90EB491ECCD6CDFF44E
-id = 8755063a5cf00f3312b113e6  hash = 07B4C2B01EB7E53DEE40407860DD3D60
-id = 0c85b0fa3ab1503d1eb123b4  hash = 0073554010938DF685424482045F6768  aux_files = {   [1] = {     name = "mm_boil.mp3",     dest = "MUSH/sounds/msp",     },   [2] = {     name = "mm_stream.mp3",     dest = "MUSH/sounds/msp",     },   }
-id = a11c9d4e484b5fc428a49941  hash = 532D433AFFB6EEC58EB0ED9CF56E4AB4
-id = 84399d3da75ce710a39635d6  hash = E9332DF2DC7912E7137334402FEEA71C
-id = 4e2bf9f75646bf678cf620dd  hash = 1626D02B0E60B9A5ECD1B573FAEE170D  aux_files = {   [1] = {     name = "ping.mp3",     dest = "MUSH/sounds",     },   }
-id = aedf0cb0be5bf045860d54b7  hash = 492249E859B0A62E0F445D16386732FA
 id = d553d532b7fd796f3c0759c8  hash = BCFFC68E800BFDE0C79775EE48BF82ED
-id = 697bd90f4f6ee5ac1493050c  hash = 600A44E005CB1D0267B3ED7D35386CEE
-id = 522cd3350766f852d36c5e5c  hash = 8259C5781FBA31ED482E9410FBC8B9DD
-id = 8e6a05d3e8bbd72d1f6a7ae8  hash = ED12CEA064A029E63716515F2D6FE1A8  aux_files = {   [1] = {     name = "mm_boil.mp3",     dest = "MUSH/sounds/msp",     },   [2] = {     name = "mm_stream.mp3",     dest = "MUSH/sounds/msp",     },   }
-id = 0084625af85a3786d14c5b8d  hash = F5745C9CE6F1450D6D66A709F20217D0
-id = cab11fa55cae7d04b2fe8b70  hash = A442C8EDAE3341BF1E4A474D2D102280
-id = adf79802005a0d6186530bee  hash = 7A2640AE88B23921E2CB4F0D251FFAE7
-id = 1d71bf1797912d451784ca21  hash = FAA74ADED4B48737E5806889CD8B9A8E
-id = 78c38a09ed49fe8a8e03ec6a  hash = AA1BB9A0AEEFFCCC13EF8343A5E114B2  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = d900cb999816b1f6f2d4bdc5  hash = A673F5198531E5872BB089A1A620D8D3
-id = 3a006258a11ad009439f9dd9  hash = 1982BD4FA441EB74CCE7389EC13C55F2
+id = e8db9e0976d964b82332096b  hash = 1B48B3C74D0B077F457713E4C2633340
+id = adc3a873d4e47348da7cb426  hash = D4639AD634A8C0013DA12D226DC98E7D  aux_files = {   [1] = {     name = "arrow.png",     },   [2] = {     name = "circ.png",     },   [3] = {     name = "cross.png",     },   [4] = {     name = "custom.png",     },   [5] = {     name = "dest.png",     },   [6] = {     name = "horse.png",     },   [7] = {     name = "ship.png",     },   [8] = {     name = "alyria.png",     },   [9] = {     name = "alyria_spk_purple.png",     },   [10] = {     name = "alyria_spk_red.png",     },   [11] = {     name = "fp.png",     },   [12] = {     name = "lasler.png",     },   [13] = {     name = "social.png",     },   [14] = {     name = "sugx.png",     },   [15] = {     name = "ug.png",     },   [16] = {     name = "verity.png",     },   }
+id = aedf0cb0be5bf045860d54b7  hash = 492249E859B0A62E0F445D16386732FA
+id = f973af093e715dece34dc25f  hash = 4E731428A97E269F0F1017B9E77752AE  aux_files = {   [1] = {     name = "mm_mapper.lua",     dest = "MUSH/lua",     },   }
+id = f67c4339ed0591a5b010d05b  hash = 19843325EE9DBAA5D4B629228EE0C9E5  aux_files = {   [1] = {     name = "gmcphelper.lua",     dest = "MUSH/lua",     },   [2] = {     name = "sandbox.dune.net.MCL",     dest = "MUSH/worlds",     },   }
 id = 925cdd0331023d9f0b8f05a7  hash = 5D9D4754247B6FC89E75296A5FA49AFE
-id = 98e6a55b66fa94328c5dc168  hash = 3EB5CCEE313C521E0AE33D9DF561E3B9
-id = 7a03ddd09375ae8c2e4ae697  hash = C16EA595B4F1A4B65E5ABE7B3A69E31D
-id = efe96b7604c453d0a92110e0  hash = 7F097EBC98703C8249F8B2C8E23739A7
-id = d692e95c094853d2b2458f58  hash = D6803B37FA785DFBDBAB1C77CD0A9DBF
-id = d81aeca9c0a10f0270dfe0f4  hash = 0BEEB67740CECE5AC34F821F68C1E5F2
-id = 3c56fcf3317c6230888de0f6  hash = 11696D3158C12126EE342E206FE60CC8  aux_files = {   [1] = {     name = "buttons.png",     },   }
-id = bc15ed541f8f0d068b9cf55f  hash = 8A9CB86DC96947F7B6BD0D7538855C45
-id = 9ced43d0a7b4a60116794096  hash = 6B631E6EC080C9D78FE24E6004DC1B3B  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 94dbcac2c9633407655fdbfa  hash = 7231FB04380803CB1DC4DB8CE515C2DE
+id = 463242566069ebfd1b379ec1  hash = 661C7BA2F78BCE66507A5DFD619F0BC1
+id = adf79802005a0d6186530bee  hash = 7A2640AE88B23921E2CB4F0D251FFAE7
+id = f99134f19ea994a0cc0888d1  hash = 2B8F2A164C0E86DFE98009A06493587E
 id = 6010f6bda5ebf2210998613d  hash = D6F2AD3A711DBE49B0F8A8377BE312D6
 id = 118122989b315b5a97526fcc  hash = E9FA534023D945C443870D6F832903A9
+id = 366aa79676f9fb1941eb5f69  hash = 559B677EBBFF0C67D154256671D7D558
+id = b2772cad800b33a6073d9377  hash = 1A954242DD7D93D4CFB40B0107B2A789  aux_files = {   [1] = {     name = "captures.MCL",     dest = "MUSH/worlds",     },   [2] = {     name = "announce.mp3",     dest = "MUSH/sounds",     },   }
 id = 0d02361abda86a9c64488bf3  hash = E0A05971F80B2FD11B0F2D57D5B85FD4  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 1df4fa3b486a36ededa19433  hash = FC54AE743D363630742D64F924DB1749
-id = cd8aa6f67b9f78ab77e67ae3  hash = A9B82909AE7E14F28B6790339DC32D4E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
-id = 9249299865b9d174ff96adbe  hash = DBC6B587BE548A26EFB1D262B5E212DB
-id = 017a906269344dcc9209af11  hash = FFBFCB6A46CFFD5773BE7926A8632A01  aux_files = {   [1] = {     name = "MM_Glass_Jar_Falling.mp3",     dest = "MUSH/sounds",     },   }
-id = 34819975b09478bd0aaa8a3d  hash = 4AECE9A8341812F7022AFE7D2FA32250
-id = 71b23c59cf79acc8521fc4a9  hash = 8CC406CE99359F8F8F1907186B70F018
-id = 4b03d42b86ed2b802247c058  hash = E1328944F0FB9417F9C8F4AE58AD3F2D
-id = e8db9e0976d964b82332096b  hash = 1B48B3C74D0B077F457713E4C2633340
-id = 6e79c67fd99121b8b383e377  hash = 47791169346537AE664C5EB3E700199B
-id = 598d2a61318e7e4604d54fe8  hash = 2EFE563F0D482FE7300A087A3505988A
-id = 783cca60ac0d776ca859de57  hash = 67FC22E2E18B9956D6725402AB22748B  aux_files = {   [1] = {     name = "tick.mp3",     dest = "MUSH/sounds",     },   }
-id = ad02c292bb640b7aee9e4df0  hash = A6DEB506BC7F502455A4F57C5D00CFA0
+id = 47150df0ca58b162ea22b396  hash = 2D8100533E6FFDDE8871DB6FD3B999FB
+id = fdebcc7a082dc4e7c6d4c306  hash = 51F28819EC963F6AEC3D56B1E793D73E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
 id = 644c7a6e7d17a3195d0d025d  hash = C540DC07ADDFE18E32D6EA920EF12A72
+id = 51a661f409c5d66601ff16e9  hash = C65C63FC0505935B7304512EF61320E4  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 7a03ddd09375ae8c2e4ae697  hash = C16EA595B4F1A4B65E5ABE7B3A69E31D
+id = 15160c25503baa781f667459  hash = CA92B58A780859FBD94348F0E524E863
+id = 9249299865b9d174ff96adbe  hash = DBC6B587BE548A26EFB1D262B5E212DB
+id = bc15ed541f8f0d068b9cf55f  hash = 8A9CB86DC96947F7B6BD0D7538855C45
+id = d900cb999816b1f6f2d4bdc5  hash = A673F5198531E5872BB089A1A620D8D3
+id = 1079f88c024e8171e2d91e76  hash = FF82E55CDA7CCCB882FF49B4AF233113
+id = 94dbcac2c9633407655fdbfa  hash = 7231FB04380803CB1DC4DB8CE515C2DE
+id = 9ced43d0a7b4a60116794096  hash = 6B631E6EC080C9D78FE24E6004DC1B3B  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 78c38a09ed49fe8a8e03ec6a  hash = AA1BB9A0AEEFFCCC13EF8343A5E114B2  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 909d8c23b717f4de1262d0a4  hash = 9F7611B9C3E432737BF55CC7BD8FE4D7
+id = a326b480b3f02b3ff6d58e7d  hash = 1FDEEDA61179DF786CE9F23BE2E259C1
+id = 97784abf5f30629a0d7e7307  hash = 1FB4EBDE61F109C1D0C2815E38EDA006
+id = d692e95c094853d2b2458f58  hash = D6803B37FA785DFBDBAB1C77CD0A9DBF
+id = 164db33914b912da8aac6ecc  hash = D80F101FB7D7B4B6238E2B8BE8D511A7
+id = 29aff4e19e96d79f40ffcbd6  hash = 1762150CF863FB19954DAF81EB491516
+id = ce9475a5d7acf80d07396cac  hash = 2714B0BDDB7F1A0421287EAF6DB85F92
+id = 0084625af85a3786d14c5b8d  hash = F5745C9CE6F1450D6D66A709F20217D0
+id = d83fdde9ed133fb0859936a6  hash = DB58EAA5FA1DFC5733DB8379190BC91B
+id = 6e79c67fd99121b8b383e377  hash = 47791169346537AE664C5EB3E700199B
+id = 4df60011beba94a6b9e41859  hash = 13BFE477E47C3F2377A5A9BE450D5E77
+id = 57ba85788195beece2a1a171  hash = F20CAE9FDAF57FA789806ED3EA72347B
+id = 98e6a55b66fa94328c5dc168  hash = 3EB5CCEE313C521E0AE33D9DF561E3B9
+id = 34819975b09478bd0aaa8a3d  hash = 4AECE9A8341812F7022AFE7D2FA32250
+id = 7ccd9d550eaeedb90ed0825d  hash = 2623D4EF22BA8BE74CFE5A4F3D0D806D
+id = 598d2a61318e7e4604d54fe8  hash = 2EFE563F0D482FE7300A087A3505988A
+id = a11c9d4e484b5fc428a49941  hash = 532D433AFFB6EEC58EB0ED9CF56E4AB4
+id = 3a006258a11ad009439f9dd9  hash = 1982BD4FA441EB74CCE7389EC13C55F2
+id = 226fb67b0722e0f0ddc3a235  hash = 18E699E79A31D4417919489EDF74C41B
+id = 84cc0397252aec0dbd589eaa  hash = F0AFB1723D2AE53FA615773488AEECE1
+id = 8755063a5cf00f3312b113e6  hash = 07B4C2B01EB7E53DEE40407860DD3D60
+id = 1df4fa3b486a36ededa19433  hash = FC54AE743D363630742D64F924DB1749
+id = 1d71bf1797912d451784ca21  hash = FAA74ADED4B48737E5806889CD8B9A8E
+id = 54846c23d8b15594e7eb4b8a  hash = 14E0D769B3192F4B43BC2D5EE5F14470
+id = 4327c10cd9ae383bef04a7fc  hash = 2CA7206FE1FC784960025F0E016C91B9
+id = cab11fa55cae7d04b2fe8b70  hash = A442C8EDAE3341BF1E4A474D2D102280
+id = 4b03d42b86ed2b802247c058  hash = E1328944F0FB9417F9C8F4AE58AD3F2D
+id = fbd5b7cc1ef6acf827a3f4a1  hash = F1C24EFCF6BB89348D62900026B2DE7C  aux_files = {   [1] = {     name = "async.lua",     dest = "MUSH/lua",     },   [2] = {     name = "ssl.lua",     dest = "MUSH/lua",     },   [3] = {     name = "https.lua",     dest = "MUSH/lua/ssl",     },   }
+id = ad02c292bb640b7aee9e4df0  hash = A6DEB506BC7F502455A4F57C5D00CFA0
+id = e377771aeee520a633f3dd4d  hash = BA5CDA1963FF9F5E15776E201DB9ED19
+id = 66f8ef96f2166bb586529087  hash = EBDA2240869865A4D3919428330F6FF8
+id = bb2a97fe72b34a0cd5135bcf  hash = 4EC4093F5BE5BC40CE73E53E9DFF9B2E
+id = d2b442f2da9a95f34f5a199f  hash = F8564564C1118A7CB5EEEF6E80B24493  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 233091f6c00f9afb14a2af62  hash = 91DAE348474D47648644945A2C3C92BF  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 4e2bf9f75646bf678cf620dd  hash = 1626D02B0E60B9A5ECD1B573FAEE170D  aux_files = {   [1] = {     name = "ping.mp3",     dest = "MUSH/sounds",     },   }
+id = 697bd90f4f6ee5ac1493050c  hash = 600A44E005CB1D0267B3ED7D35386CEE
+id = 7daf1d7890d9db73d74a8188  hash = D76B7EE02EE2A3C2F5D23F9B274D94E4
+id = 522cd3350766f852d36c5e5c  hash = 8259C5781FBA31ED482E9410FBC8B9DD
+id = dc22833520922eacc933b2ac  hash = C4117AF629283A51CD25E67A89CAA1E7
+id = ffc9367251d8355fc40c4f67  hash = 9B07AAFC27F4D9292A4A80314B762B4E
 id = 60a4b5df5d7507d9ec3d2d7a  hash = 58DE15E4A70B987A8C2C5E18CC643133
-name = world_miniwindow.lua  hash = 08868EA01E48C08BD4AA27962F655461
-name = mapper.lua  hash = 4DE33236EBF9C210304B1324A8FDD390
+id = da9c885cd98fd213dd8f719a  hash = 37159BDD68C7591F971A155BB4B95DCA
+id = ed9db27b1b50b46624e21eb4  hash = 103CACBCA97FE6985D0CB4A4B440CA80
+id = 71b23c59cf79acc8521fc4a9  hash = 8CC406CE99359F8F8F1907186B70F018
+id = 632048f8236c5a1319306ff6  hash = 62A4C2D8E7E13133C4742DD244E10224
+id = cd8aa6f67b9f78ab77e67ae3  hash = A9B82909AE7E14F28B6790339DC32D4E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = d54ccc4800e5df1ad0ed0aac  hash = 4621EB3AF63B0B777056D7F11D5FA14B
+id = d81aeca9c0a10f0270dfe0f4  hash = 0BEEB67740CECE5AC34F821F68C1E5F2
+id = 783cca60ac0d776ca859de57  hash = 67FC22E2E18B9956D6725402AB22748B  aux_files = {   [1] = {     name = "tick.mp3",     dest = "MUSH/sounds",     },   }
+id = d75d47db12b5271e7e063d46  hash = 53B7E57CC678F90EB491ECCD6CDFF44E
+id = 8e6a05d3e8bbd72d1f6a7ae8  hash = ED12CEA064A029E63716515F2D6FE1A8  aux_files = {   [1] = {     name = "mm_boil.mp3",     dest = "MUSH/sounds/msp",     },   [2] = {     name = "mm_stream.mp3",     dest = "MUSH/sounds/msp",     },   }
+id = 0c85b0fa3ab1503d1eb123b4  hash = 0073554010938DF685424482045F6768  aux_files = {   [1] = {     name = "mm_boil.mp3",     dest = "MUSH/sounds/msp",     },   [2] = {     name = "mm_stream.mp3",     dest = "MUSH/sounds/msp",     },   }
+id = 84399d3da75ce710a39635d6  hash = E9332DF2DC7912E7137334402FEEA71C
+id = 017a906269344dcc9209af11  hash = FFBFCB6A46CFFD5773BE7926A8632A01  aux_files = {   [1] = {     name = "MM_Glass_Jar_Falling.mp3",     dest = "MUSH/sounds",     },   }
+id = 3c56fcf3317c6230888de0f6  hash = 11696D3158C12126EE342E206FE60CC8  aux_files = {   [1] = {     name = "buttons.png",     },   }
+id = a6ef71f61368df7da2fcf5a6  hash = 7AC96AA0929EB975E892E7A6AEF46BB9
+id = efe96b7604c453d0a92110e0  hash = 7F097EBC98703C8249F8B2C8E23739A7
+id = 4f76c77c73affc51fa8fc841  hash = 89D928CEC6BC9728F682835D1CE52A15
+id = cb6469228f9f7e26129c1ebc  hash = A4F1F8215F5AA3F7CFBF293CB016831E  aux_files = {   [1] = {     name = "world_miniwindow.lua",     dest = "MUSH/lua",     },   }
+id = 616b8084d0f246d12d54588b  hash = D72ED2293551ABAB728E51CEB7E03F2E  aux_files = {   [1] = {     name = "generic_miniwindow.lua",     dest = "MUSH/lua",     },   }
 name = async.lua  hash = B5FED56D5E3DDE4E41DF82260C0879EE
-name = ssl.lua  hash = C67DB2536E8CE898DDA7FA8882196863
-name = mm_mapper.lua  hash = 9603238B266BFD359310989F22F199AC
+name = generic_miniwindow.lua  hash = 5A513042110FA819E28B86E465D82563
 name = gmcphelper.lua  hash = 0952EFA28EDFD7CE56E94BEBABA18E85
 name = https.lua  hash = 37D600574074246E36C7AF03C87F9E8D
-name = generic_miniwindow.lua  hash = 5A513042110FA819E28B86E465D82563
-name = ug2x.png  hash = C7C6E62CD1AA71B5E876018B70157130
-name = arrow.png  hash = 0F7BCC9C7B4CAFABE452F0E479FC02BD
-name = custom.png  hash = 37A97CF8063D2B980B1567D00ADD3122
-name = sugx.png  hash = 61213BB41BC2760BDD925A991F4D1048
-name = horse.png  hash = C49F802AA9FBE7DA95481DF49D7E9485
-name = ship.png  hash = 9D8F5C21E4ACEDC7EC1E324998504988
-name = buttons.png  hash = BEC677A70A28EF45962A5A7D5D2084D1
-name = cross.png  hash = ABAD0EBB54C250E6090EA3CD1C96E69F
-name = fp.png  hash = 93CE0042A9114AAF935AE050675C15C8
+name = mapper.lua  hash = 4DE33236EBF9C210304B1324A8FDD390
+name = mm_mapper.lua  hash = 7B95364BA75B0D502145ED5618948D78
+name = ssl.lua  hash = C67DB2536E8CE898DDA7FA8882196863
+name = world_miniwindow.lua  hash = 08868EA01E48C08BD4AA27962F655461
 name = alyria.png  hash = 5023E43A6CEAC6E4E60BD3B2135EC4A5
-name = social.png  hash = EC00E093C0ED89FF2E373CB8CCC2B053
-name = dest.png  hash = 8D086898D506D67FC24ACD312180B9DE
-name = circ.png  hash = 6702936EB3DB83A69CBA4733DCC699A2
-name = lasler.png  hash = B0D8355FA695B460E32AB6BBE0F1C4EF
 name = alyria_spk_purple.png  hash = 4B4EE3F0DDD4D2FE85751B4E91647E64
 name = alyria_spk_red.png  hash = 5E8C1597EDA4D371152CAE90BA4B7247
-name = verity.png  hash = 0346D57425CAA91EE6104C1CBE8593B9
+name = arrow.png  hash = 0F7BCC9C7B4CAFABE452F0E479FC02BD
+name = buttons.png  hash = BEC677A70A28EF45962A5A7D5D2084D1
+name = circ.png  hash = 6702936EB3DB83A69CBA4733DCC699A2
+name = cross.png  hash = ABAD0EBB54C250E6090EA3CD1C96E69F
+name = custom.png  hash = 37A97CF8063D2B980B1567D00ADD3122
+name = dest.png  hash = 8D086898D506D67FC24ACD312180B9DE
+name = fp.png  hash = 93CE0042A9114AAF935AE050675C15C8
+name = horse.png  hash = C49F802AA9FBE7DA95481DF49D7E9485
+name = lasler.png  hash = B0D8355FA695B460E32AB6BBE0F1C4EF
+name = ship.png  hash = 9D8F5C21E4ACEDC7EC1E324998504988
+name = social.png  hash = EC00E093C0ED89FF2E373CB8CCC2B053
+name = sugx.png  hash = 61213BB41BC2760BDD925A991F4D1048
 name = ug.png  hash = 3E2F8CC69040E259F007E2C74B850406
-name = mm_mapper.db  hash = 4468DD415DD643461983C8BB6E3B920F
+name = ug2x.png  hash = C7C6E62CD1AA71B5E876018B70157130
+name = verity.png  hash = 0346D57425CAA91EE6104C1CBE8593B9
 name = locations.db  hash = EC4CA63FAC2116077824C570A25E7131
-name = spdman2_locations.db  hash = 176CAE855F0408D396B74DFC3433450A
 name = meh_id.db  hash = 5ADBBE834AB885E7FA6FCC3B4CF6F1CC
+name = mm_mapper.db  hash = 4468DD415DD643461983C8BB6E3B920F
+name = spdman2_locations.db  hash = 176CAE855F0408D396B74DFC3433450A


### PR DESCRIPTION
I also updated text/create-plugins-versions.py to sort the lists of files by filename.
The resulting text/plugins_versions.txt has a lot of apparent changes due to the new sorting order (but only 2 real changes for the 2 mapper files - .xml and .lua).